### PR TITLE
Add node version dependency to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It uses [Next.js](https://nextjs.org/) and other "modern" web development tools.
 
 ## Installation
 
-If you want to run Perihelion, you will have to clone this repository and then:
+If you want to run Perihelion, you will have to clone this repository, install [Node.js](https://nodejs.org/en/) (tested on Node 14), and then:
 
 ```
 npm install


### PR DESCRIPTION
Trying out perihelion today I wasn't sure what node version to use. It looks like v14.19.3 worked and I thought it would be helpful to call that out. Maybe there is a different version you use for development that should be listed instead. 

Anyway the app is looking very nice! 