### PR TITLE
[INT] Make app name spelling consistent

### DIFF
--- a/pages/settings.js
+++ b/pages/settings.js
@@ -44,7 +44,7 @@ export default function Settings() {
   return (
     <Stack>
       <Heading color={useColorModeValue("polar.100", "snow.100")} as="h2">
-        Perihellion Settings
+        Perihelion Settings
       </Heading>
       <Container>
         <Text color={useColorModeValue("polar.100", "snow.100")} fontSize="2xl">


### PR DESCRIPTION
# Overview

Goal is to fix an inconsistency with the spelling of the name of the app.